### PR TITLE
fix: set doxymacs-mode on hook if it's pssible to load doxymacs

### DIFF
--- a/emacs/inits/20-language.el
+++ b/emacs/inits/20-language.el
@@ -83,7 +83,7 @@
 
 ;;; Doxygen
 (use-package doxymacs
-  :hook (c-mode-common . doxymacs-mode))
+  :config (add-hook 'c-mode-common-hook 'doxymacs-mode))
 
 ;;--------------------------------------------------
 ;; Configulation language


### PR DESCRIPTION
load failure after setting functions on hook.