### PR TITLE
Enable fzf new keybindings

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -36,6 +36,7 @@ set -gx LANG en_US.UTF-8
 set -gx TERM xterm-256color
 set -gx GHQ_ROOT $GOPATH/src
 set -gx TMUX_PLUGIN_MANAGER_PATH $XDG_CONFIG_HOME/tmux/plugins/
+set -gx FZF_LEGACY_KEYBINDINGS 0
 set -gx FZF_DEFAULT_OPTS '--cycle --reverse --bind "?:toggle-preview"'
 set -gx FZF_FIND_FILE_OPTS '--preview "head -100 {}"'
 set -gx FZF_CD_OPTS '--preview "tree -C {} | head -n100"'


### PR DESCRIPTION
The key binding (C-g) conflict with fish-ghq has been resolved.